### PR TITLE
ci: remove the trailing slash

### DIFF
--- a/docs/percona-account-help.md
+++ b/docs/percona-account-help.md
@@ -4,7 +4,7 @@ A Percona Account is your all-access pass to various Percona services, including
 With a Percona Account, you can sign in to any Percona service using the same email address and password. This means that you don’t need to manage separate login accounts for each service.
 
 ## Sign up for a Percona Account
-1. Go to the [Percona Account Sign Up](https://id.percona.com/signin/register/) page.
+1. Go to the [Percona Account Sign Up](https://id.percona.com/signin/register) page.
 2. Enter your work or professional email address and specify a valid password.
 3. Enter your first and last name, then click **Register** once you’ve accepted the Terms of Service and Privacy Policy. 
 4. Check your email for a verification message and follow the instructions to activate your account. 


### PR DESCRIPTION
Removing the trailing / will make the link land in the register correctly.
Having the trailing / makes okta go to the login instead of the register, without it it lands into the registration directly. Please review.