### PR TITLE
Pin the version of jinja to <3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Markdown==3.3.4
+jinja2<3.1
 mkdocs>=1.1.2
 mkdocs-versioning==0.4.0
 mkdocs-macros-plugin
@@ -6,7 +7,6 @@ mkdocs-exclude
 markdown-include
 mkdocs-material==8.2.5
 mkdocs-with-pdf>=0.8.0
-plantuml-markdown
 mkdocs-git-revision-date-plugin
 mkdocs-material-extensions
 mkdocs-bootstrap-tables-plugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ mkdocs-versioning==0.4.0
 mkdocs-macros-plugin
 mkdocs-exclude
 markdown-include
-mkdocs-material==8.2.6
+mkdocs-material==8.2.5
 mkdocs-with-pdf>=0.8.0
 plantuml-markdown
 mkdocs-git-revision-date-plugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ mkdocs-versioning==0.4.0
 mkdocs-macros-plugin
 mkdocs-exclude
 markdown-include
-mkdocs-material
+mkdocs-material==8.2.6
 mkdocs-with-pdf>=0.8.0
 plantuml-markdown
 mkdocs-git-revision-date-plugin


### PR DESCRIPTION
After the release of mkdocs-material 8.2.7 it starts to conflict with jinja2, so we are pining the version to the one that doesn't break.