### PR TITLE
feat: add CSS for animated gif

### DIFF
--- a/docs/css/gifs.css
+++ b/docs/css/gifs.css
@@ -1,0 +1,48 @@
+img {
+  display: block;
+}
+
+.screenshot {
+  border: 1px solid #000;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    position: relative;
+    box-shadow: 0 5px 30px rgb(0 0 0 / 10%);
+    margin-bottom: 1rem;
+    display: inline-block;
+    max-height: unset;
+    border: 0;
+    max-width: 100%;
+    height: auto;
+}
+
+.lazyloaded {
+      opacity: 1;
+    transition: opacity .25s;
+}
+
+.screenshot .screenshot__animated-gif {
+  display: none;
+}
+
+.screenshot:hover .screenshot__still {
+    display: none;
+}
+
+.screenshot:hover .screenshot__animated-gif {
+    display: block;
+}
+
+.screenshot:hover .screenshot__play {
+  display: none;
+}
+
+.screenshot__play .fa-play {
+  opacity: .35;
+  font-size: 1.5rem;
+  color: #fefefe;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%,-50%);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ extra_css:
   - https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css
   - css/toctree.css
   - css/percona.css
+  - css/gifs.css
   - css/table-list.css
 
 extra_javascript:


### PR DESCRIPTION
Add CSS for animated GIFs

snippet to use animated gifs:

```
<div class="screenshot">
   <a href="images/animated.gif" title="" lg-event-uid="&amp;1">
      <img alt="" src="images/still.png" data-src="images/still.png" class="screenshot__still lazyloaded">
      <img alt="" src="images/animated.gif" class="screenshot__animated-gif">
      <div class="screenshot__play">
         <i class="fa fa-play"></i>
      </div>
   </a>
</div>
```